### PR TITLE
Replaced method get_projects, added new auth header to youtrack.py 

### DIFF
--- a/sentry_youtrack/youtrack.py
+++ b/sentry_youtrack/youtrack.py
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+import os
+import json
 import requests
 import logging
 from bs4 import BeautifulSoup
@@ -25,7 +27,8 @@ class YouTrackClient(object):
     LOGIN_URL = '/rest/user/login'
     PROJECT_URL = '/rest/admin/project/<project_id>'
     PROJECT_FIELDS = '/rest/admin/project/<project_id>/customfield'
-    PROJECTS_URL = '/rest/project/all'
+    # PROJECTS_URL = '/rest/project/all'
+    PROJECTS_URL = '/api/admin/projects/?fields=name,shortName'  # ! NEW API
     CREATE_URL = '/rest/issue'
     ISSUES_URL = '/rest/issue/byproject/<project_id>'
     COMMAND_URL = '/rest/issue/<issue>/execute'
@@ -131,7 +134,9 @@ class YouTrackClient(object):
             'params': params,
             'verify': self.verify_ssl_certificate,
             'headers': {
-                'User-Agent': 'sentry-youtrack/%s' % VERSION}}
+                'User-Agent': 'sentry-youtrack/%s' % VERSION,
+                'Authorization': 'Bearer %s' % self.api_key}
+                }
 
         if hasattr(self, 'cookies'):
             kwargs['cookies'] = self.cookies
@@ -154,11 +159,20 @@ class YouTrackClient(object):
         response = self.request(url, method='get')
         return BeautifulSoup(response.text, 'xml').user
 
+    # ! OLD API DEPRECATED
+#    def get_projects(self):
+#        url = self.url + self.PROJECTS_URL
+#        response = self.request(url, method='get')
+#        data = BeautifulSoup(response.text, 'xml')
+#        for project in data.projectShorts:
+#            yield {'id': project['shortName'], 'name': project['name']}
+
+    # ! NEW API
     def get_projects(self):
         url = self.url + self.PROJECTS_URL
         response = self.request(url, method='get')
-        data = BeautifulSoup(response.text, 'xml')
-        for project in data.projectShorts:
+        data = json.loads(response.text)
+        for project in data:
             yield {'id': project['shortName'], 'name': project['name']}
 
     def get_priorities(self):
@@ -172,7 +186,6 @@ class YouTrackClient(object):
             return self._get_custom_field_values('bundle', 'Types')
         except:
             return self._get_custom_field_values('bundle', 'Типы')
-
 
     def get_project_issues(self, project_id, query=None, offset=0, limit=15):
         url = self.url + self.ISSUES_URL.replace('<project_id>', project_id)
@@ -211,3 +224,14 @@ class YouTrackClient(object):
         for field in self.get_project_fields_list(project_id):
             if not field['name'] in ignore_fields:
                 yield self._get_custom_project_field_details(field)
+
+
+if __name__ == "__main__":
+    # test new api (projects list)
+    call_api = YouTrackClient(
+        url=os.environ.get('YT_URL', ''),
+        api_key=os.environ.get('YT_TOKEN', '')
+        )
+    project = call_api.get_projects()
+    for item in range(5):
+        print(next(project))

--- a/sentry_youtrack/youtrack.py
+++ b/sentry_youtrack/youtrack.py
@@ -38,24 +38,29 @@ class YouTrackClient(object):
     API_KEY_COOKIE_NAME = 'jetbrains.charisma.main.security.PRINCIPAL'
 
     def __init__(self, url, username=None, password=None, api_key=None,
-                 verify_ssl_certificate=True):
+        verify_ssl_certificate=True):
+
         self.verify_ssl_certificate = verify_ssl_certificate
         self.url = url.rstrip('/') if url else ''
+        # ! OLD USE _login
+        # if api_key is None:
+        #     self.api_key = self._login(username, password)
+        # ! NEW USE environ YT_TOKEN
         if api_key is None:
-            self.api_key = self._login(username, password)
+            self.api_key = os.environ.get('YT_TOKEN', '')
         else:
-            self.api_key = api_key
+            self.api_key = str(api_key)  # test string field
         self.cookies = {self.API_KEY_COOKIE_NAME: self.api_key}
 
-    def _login(self, username, password):
-        credentials = {
-            'login': username,
-            'password': password}
-        url = self.url + self.LOGIN_URL
-        response = self.request(url, data=credentials, method='post')
-        if BeautifulSoup(response.text, 'xml').login is None:
-            raise requests.HTTPError('Invalid YouTrack url')
-        return response.cookies.get(self.API_KEY_COOKIE_NAME)
+    # def _login(self, username, password):
+    #     credentials = {
+    #         'login': username,
+    #         'password': password}
+    #     url = self.url + self.LOGIN_URL
+    #     response = self.request(url, data=credentials, method='post')
+    #     if BeautifulSoup(response.text, 'xml').login is None:
+    #         raise requests.HTTPError('Invalid YouTrack url')
+    #     return response.cookies.get(self.API_KEY_COOKIE_NAME)
 
     def _get_bundle(self, response, bundle='enumeration'):
         soup = BeautifulSoup(response.text, 'xml')


### PR DESCRIPTION
I'm not sure that this will fix the subsequent integration logic, since absolutely all endpoints in the old URL are disabled and no longer return data.
But using the get_projects example, you can see that the new youtrack api returns a JSON response.
To test youtrack.py as a standalone module, don't forget to export your environment variables
YT_URL
YT_TOKEN